### PR TITLE
Fix OpenAI parameter typo

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,7 +124,7 @@ def explanation():
             temperature=1.0,
             presence_penalty=1.0,
             frequency_penalty=1.0,
-            max_completion_tokens=1800
+            max_tokens=1800
             
             )
         res.append(response.choices[0].message.content)


### PR DESCRIPTION
## Summary
- correct `max_completion_tokens` to `max_tokens` in `app.py`

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683fad8986808329b54bb73c6a005600